### PR TITLE
build: create `frontend` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/main/frontend"]
+	path = src/main/frontend
+	url = https://github.com/retrotechie/rt-hris-frontend.git


### PR DESCRIPTION
`frontend` code will be stored separately from backend (`java`) code for easier code maintenace. The `frontend` submodule points to [rt-hris-frontend].

HRIS app needs to keep track of `frontend` changes for project compatibility.

Issue #17
Link:
- [rt-hris-frontend](https://github.com/retrotechie/rt-hris-frontend)

Resolve #17 